### PR TITLE
Work around spurious a2x --destination-dir warning. 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,10 +17,10 @@ rm -rf target/images
 rm -rf target/figs
 cp -r figs target
 cp -r images target
-a2x -k -fpdf -dbook --dblatex-opts=" -P doc.publisher.show=0 -P latex.output.revhistory=0  -s ./latex/custom-docbook.sty" -D target book-mvnex.asciidoc
+a2x -fpdf -dbook --dblatex-opts=" -o target/book-mvnex.pdf -P doc.publisher.show=0 -P latex.output.revhistory=0  -s ./latex/custom-docbook.sty" book-mvnex.asciidoc
 echo "done"
 
 # Build the Chunked HTML
-echo "Building Mutli Page HTML"
+echo "Building Multi Page HTML"
 a2x -k -fchunked --xsl-file=docbook-xsl/custom-chunked.xsl --xsltproc-opts "--stringparam chunk.section.depth 1" -dbook --dblatex-opts=" -P doc.publisher.show=0 -P latex.output.revhistory=0" -D target book-mvnex.asciidoc
 echo "done"


### PR DESCRIPTION
Fixes #15 

The 8.6.9 release of AsciiDoc has an issue where using `-D` with a pdf backend will work, but emit a warning.

This change uses the `dblatex` `-o` option instead of `a2x`'s `-D` to get the PDF output in the right location, with no warning. Removed the `-k` because `-o` doesn't affect the intermediate `.xml` file. 

Also fixed a typo in the progress message.