### PR TITLE
Resurrect the Style Guide

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -3,7 +3,7 @@
 === About the Book
 
 An introduction to Apache Maven as formerly published as part of the
-book Maven: The Definitive Guide. 
+book _Maven: The Definitive Guide_.
 
 The book is available in HTML and PDF format at http://www.sonatype.com/resources/books/maven-by-example[http://www.sonatype.com/resources/books/maven-by-example].
 
@@ -11,50 +11,54 @@ The book is available in HTML and PDF format at http://www.sonatype.com/resource
 === About this Project
 
 This is the source code and build setup for the book. The content is
-written in asciidoc format.  To edit asciidoc, use Emacs, vi, TextMate
+written in asciidoc format.  To edit asciidoc, use Emacs, vi, TextMate,
 or whatever other text editor you prefer.  You can even just preview
-the files right in github and edit them on the web interface directly.
+the files right in GitHub and edit them on the web interface directly.
 
 The main file for the book is
 
-* book-mvnex.asciidoc
+* `book-mvnex.asciidoc`
 
 which in turn includes a whole bunch of files named 
 
-* chapter-*.asciidoc
+* `chapter-*.asciidoc`
 
 These are all you should have to edit in terms of text content.
 
+Additional documentation for authors and contributors to this book can be found
+in the `doc/` subdirectory of the project.
+
 ==== Figures and screenshots?  
 
-Put them into figs/orig.
+Put them into `figs/orig`.
 
 The rest is taken care of by the build.
 
 ==== Anything else? 
 
-You'll see a lot of distracting files in that directory.  For now,
+You'll see a lot of distracting files in that `figs/orig` directory.  For now,
 you should just ignore them.  Actually, in general, you'll notice a
 number of distracting files in this project.  Really, just ignore
 them or contact us directly if you need something.
 
-==== How to Build the Book
+==== How to build the book
 
 I knew you'd ask that, and here's the simple answer:
 
 * Install asciidoc
 * Install dblatex and the docbook xsl style sheets
 * Install python
-* run ./build.sh
+* Run `./build.sh`
 
 Build is known to work on Mac OS X and Ubuntu. If you use something
 else you might or might not end up in trouble.
 
-=== Issues, Contributions and More
+=== Issues, Contributions, and More
 
-This book is CC licensed and we welcome your contributions. Please
-file issues and send pull requests on the github project. For further
-questions please contact us at book@sonatype.com.
+This book is CC licensed (CC BY-NC-ND 3.0 US) and we welcome your contributions.
+Please file issues and send pull requests on the GitHub project. 
+
+For further questions please contact us at book@sonatype.com.
 
 Thanks
 

--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -1,0 +1,6 @@
+== doc directory
+
+This directory contains documentation intended for contributors to the Maven
+by Example book. This material is not included in the book itself, and not 
+intended for the end reader's consumption.
+

--- a/doc/style-guide.asciidoc
+++ b/doc/style-guide.asciidoc
@@ -1,0 +1,90 @@
+== Style Guide
+
+This is a style guide for book contributors that indicates how things should
+be formatted, spelled, and so on.
+
+=== Font Conventions
+
+This book follows certain conventions for font usage. Understanding
+these conventions up front makes it easier to use this book.
+
+// This should be a definition list, except in some output formats
+// the list items are all bolded automatically, so you can't distinguisn
+// the bold from non-bold styles we're discussing here.
+
+_italic_
+
+Used for filenames, file extensions, URLs, application names,
+emphasis, and new terms when they are first introduced.
+
++constant width+
+
+Used for Java class names, methods, variables, properties, data
+types, database elements, and snippets of code that appear in text.
+
+**++constant width bold++**
+
+Used for commands you enter at the command line and to highlight
+new code inserted in a running example.
+
+__++constant width italic++__
+
+Used to annotate output.
+
+=== Maven Writing Conventions
+
+The book follows certain conventions for naming and font usage in
+relation to Apache Maven. Understanding these conventions up-front
+makes it easier to read this book.
+
+Compiler plugin::
+
+   Maven plugins are capitalized.
+
++create+ goal::
+
+   Maven goal names are displayed in a constant width font.
+
+“plugin”::
+
+   While “plug-in” (with hyphen) would be the grammatically correct
+   form, this book writes the term as “plugin” both because it is
+   easier to read and write and because it is a standard throughout
+   the Maven community.
+
+Maven Lifecycle, Maven Standard Directory Layout, Maven Plugin, Project Object Model::
+
+   Core Maven concepts are capitalized whenever they are being
+   referenced in the text.
+
++goalParameter+::
+
+   A Maven goal parameter is displayed in a constant width font.
+
++compile+ phase::
+
+   Lifecycle phases are displayed in a constant width font.
+
+=== House Style
+
+Serial comma::
+
+   This book uses https://en.wikipedia.org/wiki/Serial_comma[serial commas] (also
+   known as Oxford commas) in lists.
+
+Curly quotes::
+
+   Use curly quotes (“typographer's quotes”) everywhere in body text.
+
+==== Spellings of Particular Things
+
+This book's name is “Maven by Example”.
+
+Use American English spellings (“behavior”, “color”) and not British English spellings (“behaviour”, “colour”).
+
+Some words and phrases have variant spellings or capitalization styles, and we're using these forms in this book:
+
+* zip code
+
+
+


### PR DESCRIPTION
Back in commit 026742d8560fb235c28ca1d04bee10cf39da0ed0, Tim removed the Font and Writing Conventions sections from the book, reasoning that readers wouldn't want them for online formats.

I think these would still be useful to have as a reference for contributors to the book like authors and editors, especially if there are going to be community contributions coming through GitHub. (E.g. it'll be a place to hold notes on spelling and capitalization style decisions.) It's normal for a publishing project to have a house style guide, even if that's not exposed to the end readers.

This PR resurrects the old style guide sections as contributor documentation which is part of the project, but that won't be included in the book itself. I've copied over the old style guide, fixed up some of the font markup, and added a couple additional notes based on what I saw while reading through the book this week. This adds a new doc/ dir to hold this contributor doco and keep it separate from the `*.asciidoc` files that are part of the book proper.

Of course, feel free to correct me if I got any of the style choices wrong or overlooked something important.
