### PR TITLE
Add EPUB target to build

### DIFF
--- a/assemble.sh
+++ b/assemble.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
+#
+# assemble.sh - Assemble the web site
+#
+# The book and examples must already be built via other build steps
+# before calling this script.
 
-# fail if anything errors
+# Fail if anything errors
 set -e
-# fail if a function call is missing an argument
+# Fail if a function call is missing an argument
 set -u
 
-html=target/site/reference
-pdf=target/site/pdf
+site=target/site
+html=$site/reference
+pdf=$site/pdf
 
-rm -rf target/site/reference
-rm -rf target/site/pdf
+rm -rf $html
+rm -rf $pdf
 
 echo "Copying resources for site"
-mkdir -p target/site/reference
-mkdir -p target/site/pdf
+mkdir -p $html
+mkdir -p $pdf
 
-# this relies on the example project being build prior to this and is achieved
-# with a separate build step
+# Relies on examples already being built
 cp examples/target/mvnexbook-examples-1.0-project.zip target/site/mvnex-examples.zip
 
+# Relies on book already being built
 cp -r target/book-mvnex.chunked/* $html
 cp target/book-mvnex.pdf $pdf/mvnex-pdf.pdf
 

--- a/build.sh
+++ b/build.sh
@@ -4,15 +4,16 @@
 #
 # Options:
 #
-#   -f <formats>  - comma-separated list of formats to build. 
-#            Valid formats: pdf, chunked, html
-#            Defaults to "pdf,chunked".
+#   -f <formats>  
+#           comma-separated list of formats to build. 
+#           Valid formats: pdf, chunked, html, epub
+#           Defaults to "pdf,chunked"
 #
-#   -v            - enable verbose output
+#   -v      enable verbose output
 #
 # Environment variables used:
 #
-# ASCIIDOC - asciidoc command. Defaults to "asciidoc".
+# ASCIIDOC  asciidoc command to use. Defaults to "asciidoc".
 
 # Fail if anything errors
 set -e
@@ -34,9 +35,11 @@ IFS="," read -a formats <<< "$formats_arg"
 if [ "$verbose" = 1 ]; then 
 	vflag="-v"
 	dblatex_vflag="-V"
+	zip_vflag="-v"
 else 
 	vflag=""
   dblatex_vflag="-q"
+  zip_vflag="-q"
 fi
 if [ -z "${ASCIIDOC+x}" ]; then ASCIIDOC=asciidoc; fi
 asciidoc_exe="$ASCIIDOC"
@@ -47,7 +50,7 @@ function array_contains() {
   return 1
 }
 
-valid_formats=( pdf chunked html )
+valid_formats=( pdf chunked html epub )
 for format in ${formats[@]}; do
 	if ! array_contains "$format" "${valid_formats[@]}"; then
 		echo "Error: invalid format: '$format'" >&2
@@ -84,6 +87,16 @@ if array_contains "pdf" "${formats[@]}"; then
   echo "done"
 fi
 
+run_xslt_fcn() {
+	fcn=$1
+  if [ "$verbose" = 1 ]; then
+  	$fcn
+  else
+  	# Sadly, xsltproc lists all files written on STDERR
+  	$fcn 2>/dev/null
+  fi
+}
+
 # Build the Chunked HTML
 if array_contains "chunked" "${formats[@]}"; then
   echo "Building Multi Page HTML"
@@ -102,12 +115,7 @@ if array_contains "chunked" "${formats[@]}"; then
         ../docbook-xsl/custom-chunked.xsl \
         "$book.xml"
     }
-    if [ "$verbose" = 1 ]; then
-    	xslt_chunked
-    else
-    	# Sadly, it lists all files written on STDERR
-    	xslt_chunked 2>/dev/null
-    fi
+    run_xslt_fcn xslt_chunked
     mkdir $chunked_dir/figs
     cp ../docbook-xsl/docbook-xsl.css $chunked_dir
     cp -r ../figs/web $chunked_dir/figs
@@ -115,5 +123,45 @@ if array_contains "chunked" "${formats[@]}"; then
   [ $? = 0 ] || exit 1
   echo "done"
 fi
+
+# Build the EPUB
+if array_contains "epub" "${formats[@]}"; then
+  echo "Building EPUB"
+  $asciidoc_exe $vflag -d book -b docbook \
+    -o target/$book.xml $book_file
+  xmllint --nonet --noout --valid target/$book.xml
+  (
+  	cd target
+    epub_dir=$book.epub.d
+    mkdir -p $epub_dir
+    cd $epub_dir
+    xslt_epub() {
+      # Don't include $vflag in xsltproc. It's just *too* verbose.
+      xsltproc --stringparam chunk.section.depth 0\
+        --stringparam callout.graphics 0 --stringparam navig.graphics 0 \
+        --stringparam admon.textlabel 1 --stringparam admon.graphics 0 \
+        --stringparam toc.section.depth 1 \
+        ../../docbook-xsl/epub.xsl \
+        "../$book.xml"
+      }
+    run_xslt_fcn xslt_epub
+    oebps=OEBPS
+    cp -r ../../covers $oebps
+    mkdir $oebps/figs
+    cp -r ../../figs/web $oebps/figs
+    cp ../../docbook-xsl/docbook-xsl.css $oebps
+    mkdir -p $oebps/images/icons
+    cp -r ../../images/icons/callouts $oebps/images/icons
+
+    echo 'application/epub+zip' > mimetype
+    zip $zip_vflag -Z store ../book-mvnex.epub mimetype
+    zip $zip_vflag -r -u ../book-mvnex.epub *
+  )
+  [ $? = 0 ] || exit 1
+  echo "done"
+fi
+
+
+
 
 

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
+#
+# build.sh - Build the book in target/.
 
-# fail if anything errors
+# Fail if anything errors
 set -e
-# fail if a function call is missing an argument
+# Fail if a function call is missing an argument
 set -u
 
-mkdir -p target/images
-mkdir -p target/figs
+book_file=book-mvnex.asciidoc
 
-# Build the Single HTML Page Version
-# asciidoc -o target/book-mvnex.html book-mvnex.asciidoc 
+# Build the Single Page HTML
+# asciidoc -o target/book-mvnex.html $book_file
+
+dblatex_opts_common=" -P doc.publisher.show=0 -P latex.output.revhistory=0"
 
 # Build the PDF
 echo "Building PDF"
@@ -17,10 +20,15 @@ rm -rf target/images
 rm -rf target/figs
 cp -r figs target
 cp -r images target
-a2x -k -fpdf -dbook --dblatex-opts=" -P doc.publisher.show=0 -P latex.output.revhistory=0  -s ./latex/custom-docbook.sty" -D target book-mvnex.asciidoc
+a2x -k -f pdf -d book \
+   --dblatex-opts=" $dblatex_opts_common -s ./latex/custom-docbook.sty" \
+   -D target $book_file
 echo "done"
 
 # Build the Chunked HTML
-echo "Building Mutli Page HTML"
-a2x -k -fchunked --xsl-file=docbook-xsl/custom-chunked.xsl --xsltproc-opts "--stringparam chunk.section.depth 1" -dbook --dblatex-opts=" -P doc.publisher.show=0 -P latex.output.revhistory=0" -D target book-mvnex.asciidoc
+echo "Building Multi Page HTML"
+a2x -k -f chunked -d book \
+   --dblatex-opts=" $dblatex_opts_common " \
+   --xsl-file=docbook-xsl/custom-chunked.xsl --xsltproc-opts "--stringparam chunk.section.depth 1" \
+   -D target $book_file
 echo "done"

--- a/build.sh
+++ b/build.sh
@@ -1,34 +1,119 @@
 #!/bin/bash
 #
 # build.sh - Build the book in target/.
+#
+# Options:
+#
+#   -f <formats>  - comma-separated list of formats to build. 
+#            Valid formats: pdf, chunked, html
+#            Defaults to "pdf,chunked".
+#
+#   -v            - enable verbose output
+#
+# Environment variables used:
+#
+# ASCIIDOC - asciidoc command. Defaults to "asciidoc".
 
 # Fail if anything errors
 set -e
 # Fail if a function call is missing an argument
 set -u
 
-book_file=book-mvnex.asciidoc
+# Parse arguments
+formats_arg="pdf,chunked"
+verbose=0
+while getopts "vf:" opt; do
+	case "$opt" in
+		v)  verbose=1
+        ;;
+    f)  formats_arg=$OPTARG
+        ;;
+  esac
+done
+IFS="," read -a formats <<< "$formats_arg"
+if [ "$verbose" = 1 ]; then 
+	vflag="-v"
+	dblatex_vflag="-V"
+else 
+	vflag=""
+  dblatex_vflag="-q"
+fi
+if [ -z "${ASCIIDOC+x}" ]; then ASCIIDOC=asciidoc; fi
+asciidoc_exe="$ASCIIDOC"
+
+function array_contains() {
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  return 1
+}
+
+valid_formats=( pdf chunked html )
+for format in ${formats[@]}; do
+	if ! array_contains "$format" "${valid_formats[@]}"; then
+		echo "Error: invalid format: '$format'" >&2
+		exit 1
+	fi
+done
+
+book=book-mvnex
+book_file=$book.asciidoc
 
 # Build the Single Page HTML
-# asciidoc -o target/book-mvnex.html $book_file
+if array_contains "html" "${formats[@]}"; then
+  echo "Building Single Page HTML"
+  $asciidoc_exe $vflag -o target/$book.html $book_file
+fi
 
-dblatex_opts_common=" -P doc.publisher.show=0 -P latex.output.revhistory=0"
+dblatex_opts_common="$dblatex_vflag -P doc.publisher.show=0 -P latex.output.revhistory=0"
 
 # Build the PDF
-echo "Building PDF"
-rm -rf target/images
-rm -rf target/figs
-cp -r figs target
-cp -r images target
-a2x -k -f pdf -d book \
-   --dblatex-opts=" $dblatex_opts_common -s ./latex/custom-docbook.sty" \
-   -D target $book_file
-echo "done"
+if array_contains "pdf" "${formats[@]}"; then
+  echo "Building PDF"
+  rm -rf target/images
+  rm -rf target/figs
+  cp -r figs target
+  cp -r images target
+  $asciidoc_exe $vflag -d book -b docbook \
+    -o target/$book.xml $book_file
+  xmllint --nonet --noout --valid target/$book.xml
+  dblatex -t pdf $dblatex_opts_common \
+    -p docbook-xsl/dblatex.xsl \
+    -s latex/asciidoc-dblatex.sty \
+    -s latex/custom-docbook.sty \
+    target/$book.xml
+  echo "done"
+fi
 
 # Build the Chunked HTML
-echo "Building Multi Page HTML"
-a2x -k -f chunked -d book \
-   --dblatex-opts=" $dblatex_opts_common " \
-   --xsl-file=docbook-xsl/custom-chunked.xsl --xsltproc-opts "--stringparam chunk.section.depth 1" \
-   -D target $book_file
-echo "done"
+if array_contains "chunked" "${formats[@]}"; then
+  echo "Building Multi Page HTML"
+  $asciidoc_exe $vflag -d book -b docbook \
+    -o target/$book.xml $book_file
+  xmllint --nonet --noout --valid target/$book.xml
+  (
+  	cd target
+    chunked_dir=$book.chunked
+    xslt_chunked() { 
+      # Don't include $vflag in xsltproc. It's just *too* verbose.
+      xsltproc --stringparam chunk.section.depth 1 \
+        --stringparam callout.graphics 0 --stringparam navig.graphics 0 \
+        --stringparam admon.textlabel 1 --stringparam admon.graphics 0 \
+        --stringparam toc.section.depth 1  --stringparam base.dir "$chunked_dir" \
+        ../docbook-xsl/custom-chunked.xsl \
+        "$book.xml"
+    }
+    if [ "$verbose" = 1 ]; then
+    	xslt_chunked
+    else
+    	# Sadly, it lists all files written on STDERR
+    	xslt_chunked 2>/dev/null
+    fi
+    mkdir $chunked_dir/figs
+    cp ../docbook-xsl/docbook-xsl.css $chunked_dir
+    cp -r ../figs/web $chunked_dir/figs
+  )
+  [ $? = 0 ] || exit 1
+  echo "done"
+fi
+
+

--- a/deploy-to-production.sh
+++ b/deploy-to-production.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# fail if anything errors
+# Fail if anything errors
 set -e
-# fail if a function call is missing an argument
+# Fail if a function call is missing an argument
 set -u
 
 function rsyncToDest {

--- a/deploy-to-staging.sh
+++ b/deploy-to-staging.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# fail if anything errors
+# Fail if anything errors
 set -e
-# fail if a function call is missing an argument
+# Fail if a function call is missing an argument
 set -u
 
 function rsyncToDest {

--- a/docbook-xsl/dblatex.xsl
+++ b/docbook-xsl/dblatex.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!--
+dblatex(1) XSL user stylesheet for asciidoc(1).
+See dblatex(1) -p option.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+  <!-- TOC links in the titles, and in blue. -->
+  <xsl:param name="latex.hyperparam">colorlinks,linkcolor=blue,pdfstartview=FitH</xsl:param>
+  <xsl:param name="doc.publisher.show">1</xsl:param>
+  <xsl:param name="doc.lot.show"></xsl:param>
+  <xsl:param name="term.breakline">1</xsl:param>
+  <xsl:param name="doc.collab.show">0</xsl:param>
+  <xsl:param name="doc.section.depth">3</xsl:param>
+  <xsl:param name="table.in.float">0</xsl:param>
+  <xsl:param name="monoseq.hyphenation">0</xsl:param>
+  <xsl:param name="latex.output.revhistory">1</xsl:param>
+
+  <xsl:param name="doc.toc.show">1</xsl:param>
+
+  <!--
+    Override default literallayout template.
+  -->
+  <xsl:template match="address|literallayout[@class!='monospaced']">
+    <xsl:text>\begin{alltt}</xsl:text>
+    <xsl:text>&#10;\normalfont{}&#10;</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>&#10;\end{alltt}</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="processing-instruction('asciidoc-pagebreak')">
+    <!-- force hard pagebreak, varies from 0(low) to 4(high) -->
+    <xsl:text>\pagebreak[4] </xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="processing-instruction('asciidoc-br')">
+    <xsl:text>\newline&#10;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="processing-instruction('asciidoc-hr')">
+    <!-- draw a 444 pt line (centered) -->
+    <xsl:text>\begin{center}&#10; </xsl:text>
+    <xsl:text>\line(1,0){444}&#10; </xsl:text>
+    <xsl:text>\end{center}&#10; </xsl:text>
+  </xsl:template>
+
+</xsl:stylesheet>
+

--- a/docbook-xsl/docbook-xsl.css
+++ b/docbook-xsl/docbook-xsl.css
@@ -1,0 +1,329 @@
+/*
+  CSS stylesheet for XHTML produced by DocBook XSL stylesheets.
+*/
+
+body {
+  font-family: Georgia,serif;
+}
+
+code, pre {
+  font-family: "Courier New", Courier, monospace;
+}
+
+span.strong {
+  font-weight: bold;
+}
+
+body blockquote {
+  margin-top: .75em;
+  line-height: 1.5;
+  margin-bottom: .75em;
+}
+
+html body {
+  margin: 1em 5% 1em 5%;
+  line-height: 1.2;
+}
+
+body div {
+  margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6
+{
+  color: #527bbd;
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+div.toc p:first-child,
+div.list-of-figures p:first-child,
+div.list-of-tables p:first-child,
+div.list-of-examples p:first-child,
+div.example p.title,
+div.sidebar p.title
+{
+  font-weight: bold;
+  color: #527bbd;
+  font-family: Arial,Helvetica,sans-serif;
+  margin-bottom: 0.2em;
+}
+
+body h1 {
+  margin: .0em 0 0 -4%;
+  line-height: 1.3;
+  border-bottom: 2px solid silver;
+}
+
+body h2 {
+  margin: 0.5em 0 0 -4%;
+  line-height: 1.3;
+  border-bottom: 2px solid silver;
+}
+
+body h3 {
+  margin: .8em 0 0 -3%;
+  line-height: 1.3;
+}
+
+body h4 {
+  margin: .8em 0 0 -3%;
+  line-height: 1.3;
+}
+
+body h5 {
+  margin: .8em 0 0 -2%;
+  line-height: 1.3;
+}
+
+body h6 {
+  margin: .8em 0 0 -1%;
+  line-height: 1.3;
+}
+
+body hr {
+  border: none; /* Broken on IE6 */
+}
+div.footnotes hr {
+  border: 1px solid silver;
+}
+
+div.navheader th, div.navheader td, div.navfooter td {
+  font-family: Arial,Helvetica,sans-serif;
+  font-size: 0.9em;
+  font-weight: bold;
+  color: #527bbd;
+}
+div.navheader img, div.navfooter img {
+  border-style: none;
+}
+div.navheader a, div.navfooter a {
+  font-weight: normal;
+}
+div.navfooter hr {
+  border: 1px solid silver;
+}
+
+body td {
+  line-height: 1.2
+}
+
+body th {
+  line-height: 1.2;
+}
+
+ol {
+  line-height: 1.2;
+}
+
+ul, body dir, body menu {
+  line-height: 1.2;
+}
+
+html {
+  margin: 0; 
+  padding: 0;
+}
+
+body h1, body h2, body h3, body h4, body h5, body h6 {
+  margin-left: 0
+} 
+
+body pre {
+  margin: 0.5em 10% 0.5em 1em;
+  line-height: 1.0;
+  color: navy;
+}
+
+tt.literal, code.literal {
+  color: navy;
+}
+
+.programlisting, .screen {
+  border: 1px solid silver;
+  background: #f4f4f4;
+  margin: 0.5em 10% 0.5em 0;
+  padding: 0.5em 1em;
+}
+
+div.sidebar {
+  background: #ffffee;
+  margin: 1.0em 10% 0.5em 0;
+  padding: 0.5em 1em;
+  border: 1px solid silver;
+}
+div.sidebar * { padding: 0; }
+div.sidebar div { margin: 0; }
+div.sidebar p.title {
+  margin-top: 0.5em;
+  margin-bottom: 0.2em;
+}
+
+div.bibliomixed {
+  margin: 0.5em 5% 0.5em 1em;
+}
+
+div.glossary dt {
+  font-weight: bold;
+}
+div.glossary dd p {
+  margin-top: 0.2em;
+}
+
+dl {
+  margin: .8em 0;
+  line-height: 1.2;
+}
+
+dt {
+  margin-top: 0.5em;
+}
+
+dt span.term {
+  font-style: normal;
+  color: navy;
+}
+
+div.variablelist dd p {
+  margin-top: 0;
+}
+
+div.itemizedlist li, div.orderedlist li {
+  margin-left: -0.8em;
+  margin-top: 0.5em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+
+div.sidebar ul, div.sidebar ol {
+    margin-left: 2.8em;
+}
+
+div.itemizedlist p.title,
+div.orderedlist p.title,
+div.variablelist p.title
+{
+  margin-bottom: -0.8em;
+}
+
+div.revhistory table {
+  border-collapse: collapse;
+  border: none;
+}
+div.revhistory th {
+  border: none;
+  color: #527bbd;
+  font-family: Arial,Helvetica,sans-serif;
+}
+div.revhistory td {
+  border: 1px solid silver;
+}
+
+/* Keep TOC and index lines close together. */
+div.toc dl, div.toc dt,
+div.list-of-figures dl, div.list-of-figures dt,
+div.list-of-tables dl, div.list-of-tables dt,
+div.indexdiv dl, div.indexdiv dt
+{
+  line-height: normal;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/*
+  Table styling does not work because of overriding attributes in
+  generated HTML.
+*/
+div.table table,
+div.informaltable table
+{
+    margin-left: 0;
+    margin-right: 5%;
+    margin-bottom: 0.8em;
+}
+div.informaltable table
+{
+    margin-top: 0.4em
+}
+div.table thead,
+div.table tfoot,
+div.table tbody,
+div.informaltable thead,
+div.informaltable tfoot,
+div.informaltable tbody
+{
+    /* No effect in IE6. */
+    border-top: 3px solid #527bbd;
+    border-bottom: 3px solid #527bbd;
+}
+div.table thead, div.table tfoot,
+div.informaltable thead, div.informaltable tfoot
+{
+    font-weight: bold;
+}
+
+div.mediaobject img {
+    margin-bottom: 0.8em;
+}
+div.figure p.title,
+div.table p.title
+{
+  margin-top: 1em;
+  margin-bottom: 0.4em;
+}
+
+div.calloutlist p
+{
+  margin-top: 0em;
+  margin-bottom: 0.4em;
+}
+
+a img {
+  border-style: none;
+}
+
+@media print {
+  div.navheader, div.navfooter { display: none; }
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }

--- a/docbook-xsl/epub.xsl
+++ b/docbook-xsl/epub.xsl
@@ -19,7 +19,7 @@ Suppressed by default in Docbook XSL 1.76.1 epub.xsl.
 <xsl:param name="suppress.navigation" select="1"/>
 
 <!--
-DocBook XLS 1.75.2 doesn't handle TOCs
+DocBook XSL 1.75.2 doesn't handle TOCs
 -->
 <xsl:param name="generate.toc">
   <xsl:choose>

--- a/latex/asciidoc-dblatex.sty
+++ b/latex/asciidoc-dblatex.sty
@@ -1,0 +1,19 @@
+%%
+%% A style similar to what AsciiDoc's a2x provides
+%%
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{asciidoc}[2008/06/05 AsciiDoc DocBook Style]
+%% Just use the original package and pass the options.
+\RequirePackageWithOptions{docbook}
+
+% Sidebar is a boxed minipage that can contain verbatim.
+\renewenvironment{sidebar}[1][0.95\textwidth]{
+  \hspace{0mm}\newline%
+  \noindent\begin{Sbox}\begin{minipage}{#1}%
+  \setlength\parskip{\medskipamount}%
+}{
+  \end{minipage}\end{Sbox}\doublebox{\TheSbox}%
+}
+
+% For DocBook literallayout elements, see `./dblatex/dblatex-readme.txt`.
+\usepackage{alltt}

--- a/latex/custom-docbook.sty
+++ b/latex/custom-docbook.sty
@@ -1,5 +1,5 @@
 %%
-%% This style is derivated from the docbook one
+%% This style is derived from the docbook one
 %%
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{custom-docbook}[2011/09/28 US Trade]


### PR DESCRIPTION
This adds EPUB as one of the target formats to `build.sh`. It is not built by default, only if explicitly requested with `-f epub`, so current behavior is preserved.

The code for building the epub is based on the steps that AsciiDoc's `a2x` uses.

Depends on #35 since it uses the reworked `build.sh`
Closes #19 