### PR TITLE
Add a forgotten slash.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ if array_contains "chunked" "${formats[@]}"; then
   xmllint --nonet --noout --valid target/$book.xml
   (
   	cd target
-    chunked_dir=$book.chunked
+    chunked_dir=$book.chunked/
     xslt_chunked() { 
       # Don't include $vflag in xsltproc. It's just *too* verbose.
       xsltproc --stringparam chunk.section.depth 1 \


### PR DESCRIPTION
With the slash present, the generated HTML file go into a
sub-directory.  Without the slash, the file names just end up having a
funny-looking prefix.